### PR TITLE
Point submodule remotes to https address

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "deps/json11"]
 	path = deps/json11
-	url = git@github.com:dropbox/json11.git
+	url = https://github.com/dropbox/json11.git
 [submodule "deps/CppSQLite"]
 	path = deps/CppSQLite
-	url = git@github.com:neosmart/CppSQLite.git
+	url = https://github.com/neosmart/CppSQLite.git


### PR DESCRIPTION
Previously the two git submodules ([json11](https://github.com/dropbox/json11) & [CppSQLite](https://github.com/neosmart/CppSQLite)) were pointing to GitHub repos via SSH (git@github.com…), but accessing these repos requires publickey access (i.e., repo membership). Updating submodules would result in the following error:

```
Cloning into 'deps/CppSQLite'...
Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
Clone of 'git@github.com:neosmart/CppSQLite.git' into submodule path 'deps/CppSQLite' failed
```

Using GitHub's https protocol fixes the problem.

Once these changes are pulled in, make sure you update your working copy:

```
git submodule sync
```

Thanks! I’m very excited about [mx3](https://github.com/skabbes/mx3)!
