### PR TITLE
Fix build issues with event loop

### DIFF
--- a/include/stl.hpp
+++ b/include/stl.hpp
@@ -1,4 +1,8 @@
-// all of the standard c++11 types included
+// include all of the standard stl files
+//
+// although it may be considered bad practice to "use" namespace items in a header file,
+// these types are so intrinsic to c++ that it would be worse practice to copy these names
+// I feel the readability this provides trumps the reasons to not
 #pragma once
 #include "stl_util.hpp"
 

--- a/src/event_loop.cpp
+++ b/src/event_loop.cpp
@@ -2,12 +2,18 @@
 
 using mx3::NativeEventLoop;
 
-NativeEventLoop::NativeEventLoop() : m_thread(&NativeEventLoop::_run_loop, this) {}
+NativeEventLoop::NativeEventLoop() : m_stop(false), m_thread(&NativeEventLoop::_run_loop, this) {}
+
+NativeEventLoop::~NativeEventLoop() {
+    m_stop = true;
+    m_cv.notify_one();
+    m_thread.join();
+}
 
 void
 NativeEventLoop::post(const function<void()>& run_fn) {
     std::lock_guard<std::mutex> lock(m_mutex);
-    m_queue.push_back(run_fn);
+    m_queue.emplace(run_fn);
     m_cv.notify_one();
 }
 
@@ -16,12 +22,15 @@ NativeEventLoop::_run_loop() {
     while (true) {
         std::unique_lock<std::mutex> lk(m_mutex);
         m_cv.wait(lk, [this] {
-            return !m_queue.empty();
+            return m_stop == true || !m_queue.empty();
         });
+        if (m_stop == true) {
+            return;
+        }
 
         // copy the function off, so we can run it without holding the lock
         auto fn = m_queue.front();
-        m_queue.pop_front();
+        m_queue.pop();
         lk.unlock();
         fn();
     }

--- a/src/event_loop.hpp
+++ b/src/event_loop.hpp
@@ -1,15 +1,15 @@
 #pragma once
 #include "stl.hpp"
 #include <thread>
-#include <deque>
+#include <queue>
+#include <atomic>
 
 namespace mx3 {
 
 // an event loop system which is delegated to the host OS
 class EventLoop {
   public:
-    EventLoop();
-    virtual ~EventLoop();
+    virtual ~EventLoop() {}
     virtual void post(const function<void()>& run_fn) = 0;
 };
 
@@ -18,21 +18,17 @@ class NativeEventLoop : public mx3::EventLoop {
   public:
     NativeEventLoop();
     // todo(skabbes) make sure to cleanly shut down the event loop on destroy
-    virtual ~NativeEventLoop() {}
+    virtual ~NativeEventLoop();
     virtual void post(const function<void()>& run_fn) override;
 
   private:
     // the actual run loop runs here
     void _run_loop();
 
-    // todo(skabbes) make the ability to stop this event loop
-    // whether we should stop this loop
-    // std::atomic_bool m_stop;
-
+    std::atomic_bool m_stop;
     std::mutex m_mutex;
     std::condition_variable m_cv;
-    // todo(skabbes) maybe make this a priority queue? and give a post_priority method?
-    std::deque<function<void()>> m_queue;
+    std::queue<function<void()>> m_queue;
     std::thread m_thread;
 };
 

--- a/src/mx3.hpp
+++ b/src/mx3.hpp
@@ -2,3 +2,4 @@
 #include "api.hpp"
 #include "sql_snapshot.hpp"
 #include "event_loop.hpp"
+#include "semaphore.hpp"

--- a/src/semaphore.cpp
+++ b/src/semaphore.cpp
@@ -1,0 +1,19 @@
+#include "semaphore.hpp"
+using mx3::semaphore;
+
+semaphore::semaphore() : m_count(0) {}
+
+void
+semaphore::notify() {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_count++;
+    m_cv.notify_one();
+}
+
+void
+semaphore::wait() {
+    std::unique_lock<std::mutex> lock(m_mutex);
+    m_cv.wait(lock, [this]() { return m_count > 0; });
+    --m_count;
+}
+

--- a/src/semaphore.hpp
+++ b/src/semaphore.hpp
@@ -1,0 +1,19 @@
+#pragma once
+#include "stl.hpp"
+
+namespace mx3 {
+
+// going against naming conventions here, since this class "feels" like an stl class
+// therefore follow those conventions
+class semaphore final {
+  public:
+    semaphore();
+    void notify();
+    void wait();
+  private:
+    size_t m_count;
+    std::mutex m_mutex;
+    std::condition_variable m_cv;
+};
+
+}

--- a/test/native_event_loop.gtest.cpp
+++ b/test/native_event_loop.gtest.cpp
@@ -1,0 +1,45 @@
+#include "stl.hpp"
+#include <atomic>
+#include <gtest/gtest.h>
+
+#include <mx3/mx3.hpp>
+using namespace mx3;
+
+TEST(NativeEventLoop, ctor_dtor) {
+    NativeEventLoop loop;
+}
+
+TEST(NativeEventLoop, runs_functions) {
+    NativeEventLoop loop;
+    std::atomic_int count{41};
+    semaphore ready_sem;
+    loop.post( [&] () {
+        count++;
+        ready_sem.notify();
+    });
+    ready_sem.wait();
+    EXPECT_EQ(count, 42);
+}
+
+TEST(NativeEventLoop, runs_multi_functions) {
+    NativeEventLoop loop;
+    std::atomic_bool a_ran{false};
+    std::atomic_bool b_ran{false};
+
+    semaphore ready_sem;
+    loop.post( [&] () {
+        EXPECT_EQ(a_ran, false);
+        EXPECT_EQ(b_ran, false);
+        a_ran = true;
+    });
+    loop.post( [&] () {
+        EXPECT_EQ(a_ran, true);
+        EXPECT_EQ(b_ran, false);
+        b_ran = true;
+        ready_sem.notify();
+    });
+
+    ready_sem.wait();
+    EXPECT_EQ(a_ran, true);
+    EXPECT_EQ(b_ran, true);
+}


### PR DESCRIPTION
Also provide a clean shutdown for the c++ event loop implementation.

Fixes https://github.com/skabbes/mx3/issues/12
