### PR TITLE
gyp_main.py error searching --root-target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ build_win/
 .gradle
 
 # gyp + android
+deps/gyp
 GypAndroid.mk
 *.target.mk
 obj/

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,6 +10,3 @@
 [submodule "deps/xcode-googletest"]
 	path = deps/xcode-googletest
 	url = https://github.com/mattstevens/xcode-googletest.git
-[submodule "deps/gyp"]
-	path = deps/gyp
-	url = https://chromium.googlesource.com/external/gyp.git

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ clean:
 gyp: ./deps/gyp
 
 ./deps/gyp:
-	git clone https://chromium.googlesource.com/external/gyp.git ./deps/gyp
+	git clone --depth 1 https://chromium.googlesource.com/external/gyp.git ./deps/gyp
 
 ./deps/djinni:
 	git submodule update --init

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ clean:
 gyp: ./deps/gyp
 
 ./deps/gyp:
-	git submodule update --init
+	git clone https://chromium.googlesource.com/external/gyp.git ./deps/gyp
 
 ./deps/djinni:
 	git submodule update --init

--- a/Makefile
+++ b/Makefile
@@ -31,13 +31,13 @@ djinni:
 # instruct gyp to build using the "xcode" build generator, also specify the OS
 # (so we can conditionally compile using that var later)
 build_mac/mx3.xcodeproj: deps/gyp deps/json11 mx3.gyp djinni
-	deps/gyp/gyp mx3.gyp -DOS=mac --depth=. -f xcode --generator-output=./build_mac -Icommon.gypi
+        PYTHONPATH=deps/gyp/pylib deps/gyp/gyp mx3.gyp -DOS=mac --depth=. -f xcode --generator-output=./build_mac -Icommon.gypi
 
 build_ios/mx3.xcodeproj: deps/gyp deps/json11 mx3.gyp djinni
-	deps/gyp/gyp mx3.gyp -DOS=ios --depth=. -f xcode --generator-output=./build_ios -Icommon.gypi
+        PYTHONPATH=deps/gyp/pylib deps/gyp/gyp mx3.gyp -DOS=ios --depth=. -f xcode --generator-output=./build_ios -Icommon.gypi
 
 GypAndroid.mk: deps/gyp deps/json11 mx3.gyp djinni
-	ANDROID_BUILD_TOP=dirname $(which ndk-build) deps/gyp/gyp --depth=. -f android -DOS=android --root-target libmx3_android -Icommon.gypi mx3.gyp
+        ANDROID_BUILD_TOP=dirname PYTHONPATH=deps/gyp/pylib $(which ndk-build) deps/gyp/gyp --depth=. -f android -DOS=android --root-target libmx3_android -Icommon.gypi mx3.gyp
 
 xb-prettifier := $(shell command -v xcpretty >/dev/null 2>&1 && echo "xcpretty -c" || echo "cat")
 


### PR DESCRIPTION
adding the PYTHONPATH env variable should solve the problem.
gyp_main.py searches gyp in the system, while we should prefer the one downloaded along with the repo.